### PR TITLE
Add compute_control_result: the control together with the solver status

### DIFF
--- a/docs/src/manual/simple.md
+++ b/docs/src/manual/simple.md
@@ -104,6 +104,16 @@ u = compute_control(mpc,[0.5,1];r=[0,0])
 u = mpc.compute_control([0.5, 1], r=[0, 0])
 ```
 
+If the solver fails (for example because hard constraints are infeasible), `compute_control` throws. When a failure must not abort the surrounding loop, `compute_control_result` returns an `MPCResult` carrying the control together with the solver status instead:
+
+```julia
+result = compute_control_result(mpc, [0.5, 1]; r=[0, 0])
+result.control    # the control action (the solver's last iterate on failure)
+result.exitflag   # >0 success, <0 failure
+result.status     # the exit flag as a Symbol, e.g. :Optimal or :Infeasible
+```
+
+
 gives that the optimal control action at `x=[0.5,1]` with `r=[0,0]` is `u=-1`.
 
 Still, it is hard to draw any conclusion about wheter the controller is doing what we desire based on solving just one problem. To give a better feel of the performance of the MPC, we can create a `Simulation` for it. The following code simulates the closed-loop system, starting at `x0=[0,0]`, with a reference value `r=[1,0]`, for `N=10` time steps:

--- a/src/LinearMPC.jl
+++ b/src/LinearMPC.jl
@@ -15,6 +15,7 @@ export build_tree!
 
 include("utils.jl");
 export compute_control
+export compute_control_result, MPCResult
 export compute_control_trajectory
 include("setup.jl");
 export setup!

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,13 +41,50 @@ u = compute_control(mpc, x; p=[0.5 0.25 0.0 -0.25 -0.5])
 ```
 """
 function compute_control(mpc::MPC,x;r=nothing,d=nothing,uprev=nothing,p=nothing, check=true)
+    result = compute_control_result(mpc,x;r,d,uprev,p)
+    check && @assert(result.exitflag>=1)
+    return result.control
+end
+
+"""
+    MPCResult
+
+Result of [`compute_control_result`](@ref):
+* `control`   - the computed control action (the solver's last iterate when the problem could not be solved)
+* `exitflag`  - flag from the solver (>0 success, <0 failure)
+* `status`    - the `exitflag` as a `Symbol`, e.g. `:Optimal`, `:Soft_Optimal`, `:Infeasible`
+* `solver_info` - solver details (iterations, solve time, ...)
+"""
+struct MPCResult{I}
+    control::Vector{Float64}
+    exitflag::Int
+    status::Symbol
+    solver_info::I
+end
+
+"""
+    result = compute_control_result(mpc,x;r,d,uprev,p)
+
+Same as [`compute_control`](@ref), but return an [`MPCResult`](@ref) carrying the solver status
+alongside the control instead of asserting on it. Use this when a failed solve must not throw,
+e.g. inside a simulation loop:
+
+```julia
+result = compute_control_result(mpc, x; r=[1.0, 0.0])
+if result.exitflag >= 1
+    u = result.control
+else
+    @warn "MPC solve failed" result.status
+end
+```
+"""
+function compute_control_result(mpc::MPC,x;r=nothing,d=nothing,uprev=nothing,p=nothing)
     θ = form_parameter(mpc,x,r,d,uprev,p)
     udaqp,fval,exitflag,info = solve(mpc,θ)
-    check && @assert(exitflag>=1)
     # mpc.uprev = udaqp[1:mpc.model.nu]-mpc.K*θ[1:mpc.model.nx]
     mpc.uprev .= udaqp[1:mpc.model.nu]
     mul!(mpc.uprev, mpc.K, θ[1:mpc.model.nx], -1, 1)
-    return copy(mpc.uprev)
+    return MPCResult(copy(mpc.uprev), Int(exitflag), get(DAQP.flag2status, exitflag, :Unknown), info)
 end
 
 function compute_control(empc::ExplicitMPC,x;r=nothing,d=nothing,uprev=nothing,p=nothing, check=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,6 +76,35 @@ Random.seed!(1234)
         @test norm(control.-1.7612519326) < 1e-6
     end
 
+    @testset "Compute control result" begin
+        # Feasible problem: the result carries the same control plus the solver status. The controls
+        # are compared across two fresh controllers: a solve mutates `mpc.uprev`, so a second solve on
+        # the same object is a different problem whenever the previous control enters it.
+        mpc,range = LinearMPC.mpc_examples("invpend")
+        result = compute_control_result(mpc,[5.0;5;0;0])
+        @test result isa MPCResult
+        @test norm(result.control.-1.7612519326) < 1e-6
+        @test result.exitflag == 1
+        @test result.status === :Optimal
+        @test result.solver_info.iterations >= 0
+        mpc_b,_ = LinearMPC.mpc_examples("invpend")
+        @test result.control == LinearMPC.compute_control(mpc_b,[5.0;5;0;0])
+
+        # Infeasible problem (hard output bound violated by the state): no throw, failure reported.
+        function infeasible_mpc()
+            mpc = LinearMPC.MPC([1.0 0.1; 0.0 1.0], [0.005; 0.1;;]; C=[1.0 0.0], Np=5)
+            set_objective!(mpc; Q=[1.0], R=[0.1])
+            set_input_bounds!(mpc; umin=[-1.0], umax=[1.0])
+            set_output_bounds!(mpc; ymax=[0.5], soft=false)
+            mpc
+        end
+        result = compute_control_result(infeasible_mpc(), [2.0, 0.0])
+        @test result.exitflag < 1
+        @test result.status === :Primal_Infeasible
+        @test length(result.control) == 1
+        @test_throws AssertionError compute_control(infeasible_mpc(), [2.0, 0.0])
+    end
+
     @testset "Indicator + Product constraints" begin
         mpc = LinearMPC.MPC([-0.8;;], [1.0 0.0 1.6]; C=[1.0;;], Np=1, Nc=1)
         set_input_bounds!(mpc; umin=[-1.0, 0.0, -10.0], umax=[1.0, 1.0, 10.0])


### PR DESCRIPTION
Closes #115, following the entry point suggested there.

```julia
result = compute_control_result(mpc, x; r, d, uprev, p)
result.control      # the control action (the solver's last iterate on failure)
result.exitflag     # >0 success, <0 failure
result.status       # the flag as a Symbol, e.g. :Optimal, :Soft_Optimal, :Primal_Infeasible
result.solver_info  # DAQP's info (iterations, solve time, ...)
```

- `MPCResult{I}` is a plain struct (parametric on the info type so it stays type-stable);
  `compute_control_result` performs exactly the same solve and `uprev` bookkeeping as
  `compute_control`, which now delegates to it (`check = true/false` behave as before).
- Implemented for `MPC`; `ExplicitMPC`'s tree evaluation has no solver status, so it is left out —
  happy to add a trivially-`:Optimal` method if you prefer symmetry.
- Docstrings, a paragraph in `manual/simple.md`, and a testset (feasible: same control as
  `compute_control` on a fresh controller, `:Optimal`, info populated; infeasible hard output
  bound: `exitflag < 1`, `:Primal_Infeasible`, no throw, while `compute_control` still asserts).

One observation from writing the tests, possibly worth its own issue: after an infeasible solve,
*subsequent* `solve` calls on the same `mpc.opt_model` return `exitflag = 1` with `NaN` control —
the Julia-side DAQP workspace is not reset after a failure (the generated C resets it every call).
The tests therefore use a fresh controller per assertion. That behaviour makes the status all the
more important to surface: the second call reports `:Optimal` while returning `NaN`.

Full test suite passes locally (Julia 1.12.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNTSoj8uSmNpSqpRTor8di
